### PR TITLE
Fix idempotent password detection

### DIFF
--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -21,18 +21,16 @@
     enabled: true
 
 - name: Parse existing .my.cnf
-  shell: grep pass /home/otsmanager/.my.cnf | sed 's/password=//'
+  shell: grep -s pass /home/otsmanager/.my.cnf | sed 's/password=//'
   register: existingpass
-  args:
-    removes: /home/otsmanager/.my.cnf
 
 - name: Generate random MySQL otsmanager password
   command: openssl rand -base64 18
   register: randompass
-  when: existingpass|skipped
+  when: not existingpass.stdout
 
 - set_fact:
-    mysql_otsmanager_pass: "{{ randompass.stdout if existingpass|skipped else existingpass.stdout }}"
+    mysql_otsmanager_pass: "{{ randompass.stdout if randompass is not skipped else existingpass.stdout }}"
 
 - name: Set MySQL otsmanager password (localhost)
   mysql_user:
@@ -77,12 +75,9 @@
 - name: Ensure anonymous MySQL users are not in the database
   mysql_user:
     name: ""
-    host: "{{item}}"
+    host_all: yes
     state: absent
     check_implicit_admin: yes
-  with_items:
-    - localhost
-    - 127.0.0.1
 
 - name: Delete MySQL test database
   mysql_db:

--- a/tasks/phpmyadmin.yml
+++ b/tasks/phpmyadmin.yml
@@ -42,3 +42,11 @@
   apt:
     pkg: phpmyadmin
     state: latest
+
+# https://stackoverflow.com/a/54454108/1447395
+- name: Patch bug in Ubuntu 18.04
+  replace:
+    dest: /usr/share/phpmyadmin/libraries/sql.lib.php
+    regexp: |
+      \|\| \(count\(\$analyzed_sql_results\['select_expr'] == 1\)$
+    replace: "            || ((count($analyzed_sql_results['select_expr']) == 1)\n"

--- a/tasks/tfs.yml
+++ b/tasks/tfs.yml
@@ -23,14 +23,22 @@
   become: true
   become_user: otsmanager
 
-- name: Generate random MySQL password
+- name: Parse existing config.lua
+  shell: grep -s mysqlPass /home/otsmanager/forgottenserver/config.lua | sed -E 's/mysqlPass = "(.*)"/\1/g'
+  register: existingpass
+
+- name: Generate random MySQL forgottenserver password
   command: openssl rand -base64 18
   register: randompass
+  when: not existingpass.stdout
+
+- set_fact:
+    mysql_forgottenserver_pass: "{{ randompass.stdout if randompass is not skipped else existingpass.stdout }}"
 
 - name: Create database user for TFS
   mysql_user:
     name: forgottenserver
-    password: "{{randompass.stdout}}"
+    password: "{{mysql_forgottenserver_pass}}"
     priv: forgottenserver.*:ALL
     check_implicit_admin: yes
 
@@ -56,7 +64,7 @@
   lineinfile:
     dest: /home/otsmanager/forgottenserver/config.lua
     regexp: ^mysqlPass
-    line: 'mysqlPass = "{{randompass.stdout}}"'
+    line: 'mysqlPass = "{{mysql_forgottenserver_pass}}"'
 
 - name: Put server's IP address in config.lua
   lineinfile:


### PR DESCRIPTION
MySQL passwords were wrongly detected and/or regenerated.

Also adds a phpMyAdmin hotfix for a bug that is packaged in Ubuntu 18.04 LTS.